### PR TITLE
Use the udev rules for kobuki too

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ cd ~/ros2_ws
 # Astra device rule
 cd ~/ros2_ws/src/ros_astra_camera
 sudo cp 56-orbbec-usb.rules /etc/udev/rules.d
+# copy across the udev rules for kobuki
+rosrun kobuki_ftdi create_udev_rules
 sudo service udev reload
 sudo service udev restart
-# Kobuki-specific device link (needed until we parameterize the driver)
-sudo ln -s /dev/ttyUSB0 /dev/kobuki
 ```
 
 # Run the new nodes


### PR DESCRIPTION
No need to symlink it to a varying `ttyUSBn`. Or is this because the `kobuki_ftdi` package is getting blacklisted from the deb perhaps? Can probably do something here - put the udev rule and script in `kobuki_core` and break `kobuki_ftdi` into a separate repo which isn't necessary for the turtlebot pipeline so embedded guys don't get caught by it.
