### PR TITLE
Use ros2.repos file as a starting point for a separate turtlebot2_demo.repos

### DIFF
--- a/turtlebot2_demo.repos
+++ b/turtlebot2_demo.repos
@@ -1,0 +1,161 @@
+repositories:
+  ament/ament_cmake:
+    type: git
+    url: https://github.com/ament/ament_cmake.git
+    version: master
+  ament/ament_index:
+    type: git
+    url: https://github.com/ament/ament_index.git
+    version: master
+  ament/ament_lint:
+    type: git
+    url: https://github.com/ament/ament_lint.git
+    version: master
+  ament/ament_package:
+    type: git
+    url: https://github.com/ament/ament_package.git
+    version: master
+  ament/ament_tools:
+    type: git
+    url: https://github.com/ament/ament_tools.git
+    version: master
+  ament/gmock_vendor:
+    type: git
+    url: https://github.com/ament/gmock_vendor.git
+    version: master
+  ament/gtest_vendor:
+    type: git
+    url: https://github.com/ament/gtest_vendor.git
+    version: master
+  ament/osrf_pycommon:
+    type: git
+    url: https://github.com/osrf/osrf_pycommon.git
+    version: master
+  ament/uncrustify:
+    type: git
+    url: https://github.com/ament/uncrustify.git
+    version: master
+  eProsima/Fast-CDR:
+    type: git
+    url: https://github.com/eProsima/Fast-CDR.git
+    version: master
+  eProsima/Fast-RTPS:
+    type: git
+    url: https://github.com/eProsima/Fast-RTPS.git
+    version: 4ae016fb90ea383e00b956fcba977f486894a0e5
+  ros/class_loader:
+    type: git
+    url: https://github.com/ros/class_loader.git
+    version: ros2
+  ros/geometry2:
+    type: git
+    url: https://github.com/ros/geometry2.git
+    version: ros2
+  ros2/ament_cmake_ros:
+    type: git
+    url: https://github.com/ros2/ament_cmake_ros.git
+    version: master
+  ros2/c_utilities:
+    type: git
+    url: https://github.com/ros2/c_utilities.git
+    version: master
+  ros2/cli_tools:
+    type: git
+    url: https://github.com/ros2/cli_tools.git
+    version: master
+  ros2/common_interfaces:
+    type: git
+    url: https://github.com/ros2/common_interfaces.git
+    version: master
+  ros2/demos:
+    type: git
+    url: https://github.com/ros2/demos.git
+    version: master
+  ros2/examples:
+    type: git
+    url: https://github.com/ros2/examples.git
+    version: master
+  ros2/launch:
+    type: git
+    url: https://github.com/ros2/launch.git
+    version: master
+  ros2/poco_vendor:
+    type: git
+    url: https://github.com/ros2/poco_vendor.git
+    version: master
+  ros2/rcl:
+    type: git
+    url: https://github.com/ros2/rcl.git
+    version: master
+  ros2/rcl_interfaces:
+    type: git
+    url: https://github.com/ros2/rcl_interfaces.git
+    version: master
+#  ros2/rclc:
+#    type: git
+#    url: https://github.com/ros2/rclc.git
+#    version: master
+  ros2/rclcpp:
+    type: git
+    url: https://github.com/ros2/rclcpp.git
+    version: master
+  ros2/rclpy:
+    type: git
+    url: https://github.com/ros2/rclpy.git
+    version: master
+  ros2/realtime_support:
+    type: git
+    url: https://github.com/ros2/realtime_support.git
+    version: master
+  ros2/rmw:
+    type: git
+    url: https://github.com/ros2/rmw.git
+    version: master
+  ros2/rmw_connext:
+    type: git
+    url: https://github.com/ros2/rmw_connext.git
+    version: master
+  ros2/rmw_fastrtps:
+    type: git
+    url: https://github.com/ros2/rmw_fastrtps.git
+    version: master
+  ros2/rmw_implementation:
+    type: git
+    url: https://github.com/ros2/rmw_implementation.git
+    version: master
+  ros2/rmw_opensplice:
+    type: git
+    url: https://github.com/ros2/rmw_opensplice.git
+    version: master
+  ros2/ros1_bridge:
+    type: git
+    url: https://github.com/ros2/ros1_bridge.git
+    version: master
+  ros2/rosidl:
+    type: git
+    url: https://github.com/ros2/rosidl.git
+    version: master
+  ros2/rosidl_dds:
+    type: git
+    url: https://github.com/ros2/rosidl_dds.git
+    version: master
+  ros2/rosidl_typesupport:
+    type: git
+    url: https://github.com/ros2/rosidl_typesupport.git
+    version: master
+  ros2/system_tests:
+    type: git
+    url: https://github.com/ros2/system_tests.git
+    version: master
+  ros2/tlsf:
+    type: git
+    url: https://github.com/ros2/tlsf.git
+    version: master
+#  ros2/tutorials:
+#    type: git
+#    url: https://github.com/ros2/tutorials.git
+#    version: master
+  vendor/console_bridge:
+    type: git
+    url: https://github.com/ros/console_bridge.git
+    version: master


### PR DESCRIPTION
Copies the current ros2.repos file from https://github.com/ros2/ros2.

As this file gets out of sync with ros2/ros2 master we'll need to either synchronize it manually or come up with an alternative method for doing so.

Necessary for https://github.com/ros2/ci/pull/35
@dhood I don't have push access to the turtlebot2_demo repository so you'll have to carry this across the finish line.

