### PR TITLE
add missing sensor_msgs dependency

### DIFF
--- a/turtlebot2_drivers/package.xml
+++ b/turtlebot2_drivers/package.xml
@@ -14,6 +14,7 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
   <depend>tf2</depend>
 
   <export>


### PR DESCRIPTION
Dependency added in https://github.com/ros2/turtlebot2_demo/pull/7 but not declared in the package.xml