### PR TITLE
Update turtlebot2_demo.repos to match latest ros2.repos.

### DIFF
--- a/turtlebot2_demo.repos
+++ b/turtlebot2_demo.repos
@@ -67,6 +67,10 @@ repositories:
     type: git
     url: https://github.com/ros2/examples.git
     version: master
+  ros2/example_interfaces:
+   type: git
+   url: https://github.com/ros2/example_interfaces.git
+   version: master
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git

--- a/turtlebot2_demo.repos
+++ b/turtlebot2_demo.repos
@@ -42,7 +42,7 @@ repositories:
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
-    version: 4ae016fb90ea383e00b956fcba977f486894a0e5
+    version: master
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git
@@ -50,10 +50,6 @@ repositories:
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: master
-  ros2/c_utilities:
-    type: git
-    url: https://github.com/ros2/c_utilities.git
     version: master
   ros2/cli_tools:
     type: git
@@ -106,6 +102,10 @@ repositories:
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
+    version: master
+  ros2/rcutils:
+    type: git
+    url: https://github.com/ros2/rcutils.git
     version: master
   ros2/realtime_support:
     type: git
@@ -179,10 +179,14 @@ repositories:
     type: git
     url: https://github.com/ros2/urdfdom.git
     version: ros2
-  ros/urdfdom_headers:
+  ros2/urdfdom_headers:
     type: git
     url: https://github.com/ros2/urdfdom_headers.git
     version: math_h
+  ros2/vision_opencv:
+    type: git
+    url: https://github.com/ros2/vision_opencv.git
+    version: ros2
   vendor/console_bridge:
     type: git
     url: https://github.com/ros/console_bridge.git


### PR DESCRIPTION
This should actually make it compile again, hopefully.

Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>

connects to ros2/ros2#342