### PR TITLE
Match ros2 repos file

### DIFF
--- a/turtlebot2_demo.repos
+++ b/turtlebot2_demo.repos
@@ -171,10 +171,6 @@ repositories:
     type: git
     url: https://github.com/ros2/tlsf.git
     version: master
-  ros2/turtlebot2_demo:
-    type: git
-    url: https://github.com/ros2/turtlebot2_demo.git
-    version: master
 #  ros2/tutorials:
 #    type: git
 #    url: https://github.com/ros2/tutorials.git
@@ -213,6 +209,10 @@ repositories:
     type: git
     url: https://github.com/ros2/ros_astra_camera.git
     version: ros2
+  ros2/turtlebot2_demo:
+    type: git
+    url: https://github.com/ros2/turtlebot2_demo.git
+    version: master
 #  vendor/cartographer:
 #    type: git
 #    url: https://github.com/googlecartographer/cartographer # will be a ros2 fork at some point

--- a/turtlebot2_demo.repos
+++ b/turtlebot2_demo.repos
@@ -68,9 +68,9 @@ repositories:
     url: https://github.com/ros2/examples.git
     version: master
   ros2/example_interfaces:
-   type: git
-   url: https://github.com/ros2/example_interfaces.git
-   version: master
+    type: git
+    url: https://github.com/ros2/example_interfaces.git
+    version: master
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git


### PR DESCRIPTION
The first commit moves the turtlebot_repo in the right section.
The second commit fixes some missing whitespaces