### PR TITLE
Add ceres-solver to the turtlebot repositories.

### DIFF
--- a/turtlebot2_demo.repos
+++ b/turtlebot2_demo.repos
@@ -23,7 +23,7 @@ repositories:
 #    type: git
 #    url: https://github.com/googlecartographer/cartographer # will be a ros2 fork at some point
 #    version: master
-#  vendor/ceres-solver:
-#    type: git
-#    url: https://github.com/ceres-solver/ceres-solver # will be a ros2 fork at some point
-#    version: master
+  vendor/ceres-solver:
+    type: git
+    url: https://github.com/ros2/ceres-solver
+    version: ros2


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>

connects to ros2/ros2#342

CI (showing a build for the ros2-devel branch, which was just merged into ros2):
* TB2 Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=19)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/19/)
* TB2 Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux-aarch64&build=35)](http://ci.ros2.org/job/ci_turtlebot-demo_linux-aarch64/35/)