### PR TITLE
Enable cartographer_ros in turtlebot2_demo.repos

### DIFF
--- a/turtlebot2_demo.repos
+++ b/turtlebot2_demo.repos
@@ -1,8 +1,8 @@
 repositories:
-#  ros2/cartographer_ros:
-#    type: git
-#    url: https://github.com/ros2/cartographer_ros.git
-#    version: ros2
+  ros2/cartographer_ros:
+    type: git
+    url: https://github.com/ros2/cartographer_ros.git
+    version: ros2
   ros2/joystick_drivers:
     type: git
     url: https://github.com/ros2/joystick_drivers_from_scratch.git


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

connects to ros2/ros2#342

CI (from a previous build using ros2-devel, which was just merged into ros2):
turtlebot amd64: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=28)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/28/)
turtlebot aarch64: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux-aarch64&build=43)](http://ci.ros2.org/job/ci_turtlebot-demo_linux-aarch64/43/)