### PR TITLE
Add teleop_twist_joy to the demo repositories.

### DIFF
--- a/turtlebot2_demo.repos
+++ b/turtlebot2_demo.repos
@@ -19,6 +19,10 @@ repositories:
     type: git
     url: https://github.com/ros2/ros_astra_camera.git
     version: ros2
+  ros2/teleop_twist_joy:
+    type: git
+    url: https://github.com/ros2/teleop_twist_joy.git
+    version: ros2
   ros2/turtlebot2_demo:
     type: git
     url: https://github.com/ros2/turtlebot2_demo.git


### PR DESCRIPTION
connects to ros2/ros2#342

CI (from previous build using ros2-devel branch, recently merged into ros2):
* TB2 Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=33)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/33/)
* TB2 Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux-aarch64&build=47)](http://ci.ros2.org/job/ci_turtlebot-demo_linux-aarch64/47/)