### PR TITLE
use ament_index_python to find package share dir

### DIFF
--- a/turtlebot2_drivers/launch/turtlebot_carto_2d.py
+++ b/turtlebot2_drivers/launch/turtlebot_carto_2d.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from launch.exit_handler import default_exit_handler, restart_exit_handler
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch.exit_handler import restart_exit_handler
+
 
 def launch(launch_descriptor, argv):
     ld = launch_descriptor
@@ -32,7 +36,10 @@ def launch(launch_descriptor, argv):
         exit_handler=restart_exit_handler,
     )
     ld.add_process(
-        cmd=['static_transform_publisher', '0', '0', '0', '0', '0', '0', '1', 'base_link', 'camera_depth_frame'],
+        cmd=[
+            'static_transform_publisher',
+            '0', '0', '0', '0', '0', '0', '1', 'base_link', 'camera_depth_frame'
+        ],
         name='static_transform_publisher',
         exit_handler=restart_exit_handler,
     )
@@ -46,8 +53,14 @@ def launch(launch_descriptor, argv):
         name='teleop_node',
         exit_handler=restart_exit_handler,
     )
+    cartographer_ros_prefix = get_package_share_directory('cartographer_ros')
+    cartographer_config_dir = os.path.join(cartographer_ros_prefix, 'configuration_files')
     ld.add_process(
-        cmd=['cartographer_node', '-configuration_directory', '/home/ubuntu/ros2_ws-new-cart/install_isolated/cartographer_ros/share/cartographer_ros/configuration_files', '-configuration_basename', 'turtlebot_2d.lua'],
+        cmd=[
+            'cartographer_node',
+            '-configuration_directory', cartographer_config_dir,
+            '-configuration_basename', 'turtlebot_2d.lua'
+        ],
         name='cartographer_node',
         exit_handler=restart_exit_handler,
     )

--- a/turtlebot2_drivers/package.xml
+++ b/turtlebot2_drivers/package.xml
@@ -18,6 +18,8 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 
+  <exec_depend>ament_index_python</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
@clalancette this should get rid of your hard coded path. I tested it by printing out directories, but I don't have a machine setup to test the whole thing yet.

I added convenience functions to `ament_index_python` to make this slightly easier. Pull request to follow.