### PR TITLE
Disable the RGB and IR cameras when launching the tb2 carto demo.

### DIFF
--- a/turtlebot2_drivers/launch/turtlebot_carto_2d.py
+++ b/turtlebot2_drivers/launch/turtlebot_carto_2d.py
@@ -26,7 +26,7 @@ def launch(launch_descriptor, argv):
         exit_handler=restart_exit_handler,
     )
     ld.add_process(
-        cmd=['astra_camera_node', '-dw', '320', '-dh', '240'],
+        cmd=['astra_camera_node', '-dw', '320', '-dh', '240', '-C', '-I'],
         name='astra_camera_node',
         exit_handler=restart_exit_handler,
     )

--- a/turtlebot2_drivers/launch/turtlebot_carto_3d.py
+++ b/turtlebot2_drivers/launch/turtlebot_carto_3d.py
@@ -26,7 +26,7 @@ def launch(launch_descriptor, argv):
         exit_handler=restart_exit_handler,
     )
     ld.add_process(
-        cmd=['astra_camera_node', '-dw', '320', '-dh', '240'],
+        cmd=['astra_camera_node', '-dw', '320', '-dh', '240', '-C', '-I'],
         name='astra_camera_node',
         exit_handler=restart_exit_handler,
     )


### PR DESCRIPTION
It makes the demo a bit more reliable, and uses less CPU.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>