### PR TITLE
Make sure to fully initialize the QoS structures.

### DIFF
--- a/turtlebot2_drivers/src/kobuki_node.cpp
+++ b/turtlebot2_drivers/src/kobuki_node.cpp
@@ -63,13 +63,13 @@ int main(int argc, char * argv[])
   // TODO(clalancette): we set the depth to 50 here since it seems to help workaround
   // a bug where rclcpp::spin_some() can go into an infinite loop sometimes.  We should
   // find and fix the root cause instead of this workaround.
-  rmw_qos_profile_t cmd_vel_qos_profile;
+  rmw_qos_profile_t cmd_vel_qos_profile = rmw_qos_profile_sensor_data;
   cmd_vel_qos_profile.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
   cmd_vel_qos_profile.depth = 50;
   cmd_vel_qos_profile.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
   cmd_vel_qos_profile.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 
-  rmw_qos_profile_t odom_and_imu_qos_profile;
+  rmw_qos_profile_t odom_and_imu_qos_profile = rmw_qos_profile_sensor_data;
   odom_and_imu_qos_profile.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
   odom_and_imu_qos_profile.depth = 50;
   odom_and_imu_qos_profile.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;

--- a/turtlebot2_follower/src/follower.cpp
+++ b/turtlebot2_follower/src/follower.cpp
@@ -114,7 +114,7 @@ private:
     private_nh.getParam("enabled", enabled_);
 */
 
-    rmw_qos_profile_t cmd_vel_qos_profile;
+    rmw_qos_profile_t cmd_vel_qos_profile = rmw_qos_profile_sensor_data;
     cmd_vel_qos_profile.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
     cmd_vel_qos_profile.depth = 50;
     cmd_vel_qos_profile.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;


### PR DESCRIPTION
There are additional structure members that were being left
as garbage.  Make sure to assign to a default before modifying
the structure.

This should fix: ros2/rosdistro#5

CI:
* TB2 Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=58)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/58/)
* TB2 Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux-aarch64&build=74)](http://ci.ros2.org/job/ci_turtlebot-demo_linux-aarch64/74/)