### PR TITLE
Fix dependency key name for turtlebot2_drivers

### DIFF
--- a/turtlebot2_follower/package.xml
+++ b/turtlebot2_follower/package.xml
@@ -15,7 +15,7 @@
   <exec_depend>astra_camera</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>ros2run</exec_depend>
-  <exec_depend>turtlebot_drivers</exec_depend>
+  <exec_depend>turtlebot2_drivers</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
@mikaelarguedas I think this is just a simple typo. Because the key targets an in-workspace dependency  I think we default to running CI for this change even though I think it works now due to lucking out with build ordering.