### PR TITLE
Install parameter bridge config too

### DIFF
--- a/turtlebot2_amcl/CMakeLists.txt
+++ b/turtlebot2_amcl/CMakeLists.txt
@@ -11,11 +11,8 @@ endif()
 
 install(
   DIRECTORY
+  config
   examples
-  DESTINATION share/${PROJECT_NAME})
-
-install(
-  DIRECTORY
   launch
   DESTINATION share/${PROJECT_NAME})
 


### PR DESCRIPTION
nice-to-have for readme so it can be referenced without using the source path