### PR TITLE
Disable strict-aliasing warnings in the kobuki driver.

### DIFF
--- a/turtlebot2_drivers/src/kobuki_node.cpp
+++ b/turtlebot2_drivers/src/kobuki_node.cpp
@@ -24,9 +24,9 @@
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wignored-qualifiers"
 # pragma GCC diagnostic ignored "-Wsign-compare"
+# pragma GCC diagnostic ignored "-Wstrict-aliasing"
 # pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 # pragma GCC diagnostic ignored "-Wunused-parameter"
-# pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 #include "kobuki_driver/kobuki.hpp"
 #ifndef _WIN32

--- a/turtlebot2_drivers/src/kobuki_node.cpp
+++ b/turtlebot2_drivers/src/kobuki_node.cpp
@@ -26,6 +26,7 @@
 # pragma GCC diagnostic ignored "-Wsign-compare"
 # pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 # pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 #include "kobuki_driver/kobuki.hpp"
 #ifndef _WIN32


### PR DESCRIPTION
When compiling in Release mode, it spits out a warning about
strict-aliasing down in the included ROS1 code.  Just disable
the warning when we #include that code.

Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=83)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/83/)