### PR TITLE
Add urg_node to enable cartographer mapping using Hokuyo Lidar

### DIFF
--- a/turtlebot2_cartographer/configuration_files/turtlebot_lidar_2d.lua
+++ b/turtlebot2_cartographer/configuration_files/turtlebot_lidar_2d.lua
@@ -1,0 +1,47 @@
+-- Copyright 2016 The Cartographer Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+include "map_builder.lua"
+include "trajectory_builder.lua"
+
+options = {
+  map_builder = MAP_BUILDER,
+  trajectory_builder = TRAJECTORY_BUILDER,
+  map_frame = "map",
+  tracking_frame = "gyro_link",
+  published_frame = "odom",
+  odom_frame = "odom",
+  provide_odom_frame = false,
+  use_odometry = true,
+  use_laser_scan = true,
+  use_multi_echo_laser_scan = false,
+  num_point_clouds = 0,
+  lookup_transform_timeout_sec = 0.2,
+  submap_publish_period_sec = 0.3,
+  pose_publish_period_sec = 5e-3,
+}
+
+MAP_BUILDER.use_trajectory_builder_2d = true
+
+TRAJECTORY_BUILDER_2D.min_range = 0.1
+TRAJECTORY_BUILDER_2D.max_range = 20.
+TRAJECTORY_BUILDER_2D.missing_data_ray_length = 5.
+TRAJECTORY_BUILDER_2D.use_imu_data = true
+TRAJECTORY_BUILDER_2D.use_online_correlative_scan_matching = true
+TRAJECTORY_BUILDER_2D.motion_filter.max_angle_radians = math.rad(0.1)
+
+SPARSE_POSE_GRAPH.constraint_builder.min_score = 0.65
+SPARSE_POSE_GRAPH.constraint_builder.global_localization_min_score = 0.7
+
+return options

--- a/turtlebot2_cartographer/launch/turtlebot_carto_lidar_2d.py
+++ b/turtlebot2_cartographer/launch/turtlebot_carto_lidar_2d.py
@@ -1,0 +1,68 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch.exit_handler import restart_exit_handler
+from ros2run.api import get_executable_path
+
+
+def launch(launch_descriptor, argv):
+    ld = launch_descriptor
+    package = 'turtlebot2_drivers'
+    ld.add_process(
+        cmd=[get_executable_path(package_name=package, executable_name='kobuki_node')],
+        name='kobuki_node',
+        exit_handler=restart_exit_handler,
+    )
+    package = 'urg_node'
+    ld.add_process(
+        cmd=[get_executable_path(package_name=package, executable_name='urg_node')],
+        name='urg_node',
+        exit_handler=restart_exit_handler,
+    )
+    package = 'tf2_ros'
+    ld.add_process(
+        cmd=[
+            get_executable_path(
+                package_name=package, executable_name='static_transform_publisher'),
+            '0.0', '0.0', '0.48',
+            '0', '0', '0', '1',
+            'base_link',
+            'laser',
+        ],
+        name='static_tf_pub_laser',
+        exit_handler=restart_exit_handler,
+    )
+    package = 'teleop_twist_joy'
+    ld.add_process(
+        cmd=[get_executable_path(package_name=package, executable_name='teleop_node')],
+        name='teleop_node',
+        exit_handler=restart_exit_handler,
+    )
+    package = 'cartographer_ros'
+    turtlebot2_cartographer_prefix = get_package_share_directory('turtlebot2_cartographer')
+    cartographer_config_dir = os.path.join(turtlebot2_cartographer_prefix, 'configuration_files')
+    ld.add_process(
+        cmd=[
+            get_executable_path(package_name=package, executable_name='cartographer_node'),
+            '-configuration_directory', cartographer_config_dir,
+            '-configuration_basename', 'turtlebot_lidar_2d.lua'
+        ],
+        name='cartographer_node',
+        exit_handler=restart_exit_handler,
+    )
+
+    return ld


### PR DESCRIPTION
Add one launch file (turtlebot_carto_lidar_2d.py) and configure file (turtlebot_lidar_2d.lua - adjust max_range) to enable Hokuyo Lidar for cartographer SLAM. Simply works on hokuyo UTM-30LX. 

But this depend on urg_node (https://github.com/bponsler/urg_node.git) (ros2_devel branch).
Download related packages and build by ament command, other dependent packages could be installed by apt-get install ros-r2b2-*
ament build --build-tests --symlink-install --isolated --only urg_node urg_node_msgs  diagnostic_updater ros2_time laser_proc urg_c