### PR TITLE
Fix the build error with package ceres_solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Reason for each dependency:
 
 ### Build the ros2 code
 
-For resource constrained platforms we will split te build into 2 steps to make sure not to overflow the memory
+For resource constrained platforms we will split the build into 2 steps to make sure not to overflow the memory
 ```bash
 src/ament/ament_tools/scripts/ament.py build --isolated --symlink-install --parallel --skip-packages cartographer cartographer_ros ros1_bridge turtlebot2_amcl turtlebot2_drivers turtlebot2_follower turtlebot2_cartographer turtlebot2_teleop
 ```

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ Reason for each dependency:
 
 For resource constrained platforms we will split te build into 2 steps to make sure not to overflow the memory
 ```bash
-src/ament/ament_tools/scripts/ament.py build --isolated --symlink-install --parallel --skip-packages cartographer cartographer_ros ceres_solver ros1_bridge turtlebot2_amcl turtlebot2_drivers turtlebot2_follower turtlebot2_cartographer turtlebot2_teleop
+src/ament/ament_tools/scripts/ament.py build --isolated --symlink-install --parallel --skip-packages cartographer cartographer_ros ros1_bridge turtlebot2_amcl turtlebot2_drivers turtlebot2_follower turtlebot2_cartographer turtlebot2_teleop
 ```
 
 Now the resource intensive packages and the ones depending on ROS1 packages:
 ```bash
 source /opt/ros/kinetic/setup.bash
-src/ament/ament_tools/scripts/ament.py build --isolated --symlink-install --parallel --only cartographer cartographer_ros ceres_solver turtlebot2_amcl turtlebot2_cartographer turtlebot2_drivers turtlebot2_follower turtlebot2_teleop --make-flags -j2 -l2
+src/ament/ament_tools/scripts/ament.py build --isolated --symlink-install --parallel --only cartographer cartographer_ros turtlebot2_amcl turtlebot2_cartographer turtlebot2_drivers turtlebot2_follower turtlebot2_teleop --make-flags -j2 -l2
 ```
 Go grab a coffee (or a meal if you compile on ARM)
 


### PR DESCRIPTION
ceres_solver uses upstream version in libceres-dev, remove it
from build commandline, or package not found build error occurs

Signed-off-by: Ethan Gao <ethan.gao@intel.com>