### PR TITLE
remove cartographer from the repos file

### DIFF
--- a/turtlebot2_demo.repos
+++ b/turtlebot2_demo.repos
@@ -39,7 +39,3 @@ repositories:
     type: git
     url: https://github.com/ros2/vision_opencv.git
     version: ros2
-  vendor/cartographer:
-    type: git
-    url: https://github.com/ros2/cartographer
-    version: ros2


### PR DESCRIPTION
As of bouncy we will use the version packages in ros-melodic: 0.3.0 so we don't need to build and provide a custom version anymore

Connects to ros2/ros2#481