### PR TITLE
Add a semicolon to the end of all RCUTILS and RCLCPP macros.

### DIFF
--- a/depthimage_to_pointcloud2/src/depthimage_to_pointcloud2_node.cpp
+++ b/depthimage_to_pointcloud2/src/depthimage_to_pointcloud2_node.cpp
@@ -38,7 +38,7 @@ static void depthCb(const sensor_msgs::msg::Image::SharedPtr image)
 
   if (nullptr == g_cam_info) {
     // we haven't gotten the camera info yet, so just drop until we do
-    RCUTILS_LOG_WARN("No camera info, skipping point cloud conversion")
+    RCUTILS_LOG_WARN("No camera info, skipping point cloud conversion");
     return;
   }
 
@@ -66,7 +66,7 @@ static void depthCb(const sensor_msgs::msg::Image::SharedPtr image)
     depthimage_to_pointcloud2::convert<float>(image, cloud_msg, model);
   } else {
     RCUTILS_LOG_WARN_THROTTLE(RCUTILS_STEADY_TIME, 5000,
-      "Depth image has unsupported encoding [%s]", image->encoding.c_str())
+      "Depth image has unsupported encoding [%s]", image->encoding.c_str());
     return;
   }
 

--- a/turtlebot2_drivers/src/kobuki_node.cpp
+++ b/turtlebot2_drivers/src/kobuki_node.cpp
@@ -57,7 +57,7 @@ static void cmdVelCallback(const geometry_msgs::msg::Twist::SharedPtr msg)
   double vyaw = std::min(std::max(msg->angular.z, -g_max_vyaw), g_max_vyaw);
   g_kobuki->setBaseControl(vx, vyaw);
   if (rcutils_system_time_now(&g_last_cmd_vel_time) != RCUTILS_RET_OK) {
-    RCLCPP_ERROR(g_logger, "Failed to get system time")
+    RCLCPP_ERROR(g_logger, "Failed to get system time");
   }
 }
 
@@ -110,9 +110,9 @@ int main(int argc, char * argv[])
   g_max_vyaw = 1.0;
   node->get_parameter("max_vyaw", g_max_vyaw);
 
-  RCLCPP_DEBUG(node->get_logger(), "device_port: %s", parameters.device_port.c_str())
-  RCLCPP_DEBUG(node->get_logger(), "max_vx: %f", g_max_vx)
-  RCLCPP_DEBUG(node->get_logger(), "max_vyaw: %f", g_max_vyaw)
+  RCLCPP_DEBUG(node->get_logger(), "device_port: %s", parameters.device_port.c_str());
+  RCLCPP_DEBUG(node->get_logger(), "max_vx: %f", g_max_vx);
+  RCLCPP_DEBUG(node->get_logger(), "max_vyaw: %f", g_max_vyaw);
 
   parameters.sigslots_namespace = "/kobuki";
   parameters.enable_acceleration_limiter = true;
@@ -147,7 +147,7 @@ int main(int argc, char * argv[])
       gyro_yaw = g_kobuki->getHeading();
       gyro_vyaw = g_kobuki->getAngularVelocity();
       if (rcutils_system_time_now(&now) != RCUTILS_RET_OK) {
-        RCLCPP_ERROR(node->get_logger(), "Failed to get system time")
+        RCLCPP_ERROR(node->get_logger(), "Failed to get system time");
       }
       if ((now - g_last_cmd_vel_time) > 200) {
         g_kobuki->setBaseControl(0.0, 0.0);


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Connects to https://github.com/ros2/rcutils/issues/113